### PR TITLE
Force loading of all aliases at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Therefore it is possible to set the following option in your *root* `composer.js
     },
 ```
 
+In cases where another autoloader conflicts with the alias autoloader, you may find it helpful to bypass the autoloader
+entirely, and choose to instead force the loading of all known aliases at boot. 
+
+```
+    "extra": {
+        "typo3/class-alias-loader": {
+            "autoloader-mode": "force-alias-loading"
+        }
+    },
+```
+This method of loading aliases may incur a significant performance hit if you have a large number of classes aliased.
+The class aliases are also established without loading the classes themselves.
 
 ## Using the API
 

--- a/src/ClassAliasLoader.php
+++ b/src/ClassAliasLoader.php
@@ -109,6 +109,21 @@ class ClassAliasLoader
     }
 
     /**
+     * Alternative to using as an autoloader, which pre-loads all aliases.
+     * This does NOT perform any checks against the RealClassName, as classes are not auto-loaded with this function.
+     */
+    public function registerAllAliases()
+    {
+        foreach($this->aliasMap['classNameToAliasMapping'] as $originalClassName) {
+            foreach ($this->aliasMap['classNameToAliasMapping'][$originalClassName] as $aliasClassName) {
+                if (!$this->classOrInterfaceExists($aliasClassName)) {
+                    class_alias($originalClassName, $aliasClassName);
+                }
+            }
+        }
+    }
+
+    /**
      * Main class loading method registered with spl_autoload_register()
      *
      * @param string $className

--- a/src/ClassAliasLoader.php
+++ b/src/ClassAliasLoader.php
@@ -37,6 +37,11 @@ class ClassAliasLoader
     protected $caseSensitiveClassLoading = true;
 
     /**
+     * @var bool
+     */
+    protected $forceAliasLoading = false;
+
+    /**
      * @param ComposerClassLoader $composerClassLoader
      */
     public function __construct(ComposerClassLoader $composerClassLoader)
@@ -60,6 +65,14 @@ class ClassAliasLoader
     public function setCaseSensitiveClassLoading($caseSensitiveClassLoading)
     {
         $this->caseSensitiveClassLoading = $caseSensitiveClassLoading;
+    }
+
+    /**
+     * @param boolean $forceAliasLoading
+     */
+    public function setForceAliasLoading($forceAliasLoading)
+    {
+        $this->forceAliasLoading = $forceAliasLoading;
     }
 
     /**
@@ -96,8 +109,12 @@ class ClassAliasLoader
      */
     public function register($prepend = false)
     {
-        $this->composerClassLoader->unregister();
-        spl_autoload_register(array($this, 'loadClassWithAlias'), true, $prepend);
+        if ($this->forceAliasLoading) {
+            $this->registerAllAliases();
+        } else {
+            $this->composerClassLoader->unregister();
+            spl_autoload_register(array($this, 'loadClassWithAlias'), true, $prepend);
+        }
     }
 
     /**

--- a/src/ClassAliasLoader.php
+++ b/src/ClassAliasLoader.php
@@ -131,8 +131,8 @@ class ClassAliasLoader
      */
     public function registerAllAliases()
     {
-        foreach($this->aliasMap['classNameToAliasMapping'] as $originalClassName) {
-            foreach ($this->aliasMap['classNameToAliasMapping'][$originalClassName] as $aliasClassName) {
+        foreach($this->aliasMap['classNameToAliasMapping'] as $originalClassName => $maps) {
+            foreach ($maps as $aliasClassName) {
                 if (!$this->classOrInterfaceExists($aliasClassName)) {
                     class_alias($originalClassName, $aliasClassName);
                 }

--- a/src/ClassAliasMapGenerator.php
+++ b/src/ClassAliasMapGenerator.php
@@ -137,6 +137,7 @@ class ClassAliasMapGenerator
         // Autoloader mode check
         $autoloadMode = $mainPackageAliasLoaderConfig->get(\TYPO3\ClassAliasLoader\Config::OPTION_AUTOLOAD_MODE);
         $forceAliasLoading = ($autoloadMode == \TYPO3\ClassAliasLoader\Config::AUTOLOAD_MODE_FORCE_ALIAS_LOADING);
+        $forceAliasLoadingString = $forceAliasLoading ? 'true' : 'false';
 
         $aliasLoaderInitClassContent = <<<EOF
 <?php
@@ -157,7 +158,7 @@ class ClassAliasLoaderInit$suffix {
         \$classAliasLoader = new TYPO3\ClassAliasLoader\ClassAliasLoader(\$composerClassLoader);
         \$classAliasLoader->setAliasMap(\$classAliasMap);
         \$classAliasLoader->setCaseSensitiveClassLoading($caseSensitiveClassLoadingString);
-        \$classAliasLoader->setForceAliasLoading($forceAliasLoading);
+        \$classAliasLoader->setForceAliasLoading($forceAliasLoadingString);
         \$classAliasLoader->register($prependAutoloader);
 
         TYPO3\ClassAliasLoader\ClassAliasMap::setClassAliasLoader(\$classAliasLoader);

--- a/src/ClassAliasMapGenerator.php
+++ b/src/ClassAliasMapGenerator.php
@@ -136,7 +136,7 @@ class ClassAliasMapGenerator
 
         // Autoloader mode check
         $autoloadMode = $mainPackageAliasLoaderConfig->get(\TYPO3\ClassAliasLoader\Config::OPTION_AUTOLOAD_MODE);
-        $autoloadModeForceAliasLoad = \TYPO3\ClassAliasLoader\Config::AUTOLOAD_MODE_FORCE_ALIAS_LOADING;
+        $forceAliasLoading = ($autoloadMode == \TYPO3\ClassAliasLoader\Config::AUTOLOAD_MODE_FORCE_ALIAS_LOADING);
 
         $aliasLoaderInitClassContent = <<<EOF
 <?php
@@ -157,11 +157,8 @@ class ClassAliasLoaderInit$suffix {
         \$classAliasLoader = new TYPO3\ClassAliasLoader\ClassAliasLoader(\$composerClassLoader);
         \$classAliasLoader->setAliasMap(\$classAliasMap);
         \$classAliasLoader->setCaseSensitiveClassLoading($caseSensitiveClassLoadingString);
-        if ($autoloadMode == $autoloadModeForceAliasLoad) {
-            \$classAliasLoader->registerAllAliases($prependAutoloader);
-        } else {
-            \$classAliasLoader->register($prependAutoloader);
-        }
+        \$classAliasLoader->setForceAliasLoading($forceAliasLoading);
+        \$classAliasLoader->register($prependAutoloader);
 
         TYPO3\ClassAliasLoader\ClassAliasMap::setClassAliasLoader(\$classAliasLoader);
 

--- a/src/ClassAliasMapGenerator.php
+++ b/src/ClassAliasMapGenerator.php
@@ -107,8 +107,8 @@ class ClassAliasMapGenerator
         }
 
         $mainPackageAliasLoaderConfig = new \TYPO3\ClassAliasLoader\Config($mainPackage);
-        $alwaysAddAliasLoader = $mainPackageAliasLoaderConfig->get('always-add-alias-loader');
-        $caseSensitiveClassLoading = $mainPackageAliasLoaderConfig->get('autoload-case-sensitivity');
+        $alwaysAddAliasLoader = $mainPackageAliasLoaderConfig->get(\TYPO3\ClassAliasLoader\Config::OPTION_ALWAYS_ADD_ALIAS_LOADER);
+        $caseSensitiveClassLoading = $mainPackageAliasLoaderConfig->get(\TYPO3\ClassAliasLoader\Config::OPTION_AUTOLOAD_IS_CASE_SENSITIVE);
 
         if (!$alwaysAddAliasLoader && !$classAliasMappingFound && $caseSensitiveClassLoading) {
             // No mapping found in any package and no insensitive class loading active. We return early and skip rewriting
@@ -134,6 +134,10 @@ class ClassAliasMapGenerator
 
         $prependAutoloader = $config->get('prepend-autoloader') === false ? 'false' : 'true';
 
+        // Autoloader mode check
+        $autoloadMode = $mainPackageAliasLoaderConfig->get(\TYPO3\ClassAliasLoader\Config::OPTION_AUTOLOAD_MODE);
+        $autoloadModeForceAliasLoad = \TYPO3\ClassAliasLoader\Config::AUTOLOAD_MODE_FORCE_ALIAS_LOADING;
+
         $aliasLoaderInitClassContent = <<<EOF
 <?php
 
@@ -153,7 +157,11 @@ class ClassAliasLoaderInit$suffix {
         \$classAliasLoader = new TYPO3\ClassAliasLoader\ClassAliasLoader(\$composerClassLoader);
         \$classAliasLoader->setAliasMap(\$classAliasMap);
         \$classAliasLoader->setCaseSensitiveClassLoading($caseSensitiveClassLoadingString);
-        \$classAliasLoader->register($prependAutoloader);
+        if ($autoloadMode == $autoloadModeForceAliasLoad) {
+            \$classAliasLoader->registerAllAliases($prependAutoloader);
+        } else {
+            \$classAliasLoader->register($prependAutoloader);
+        }
 
         TYPO3\ClassAliasLoader\ClassAliasMap::setClassAliasLoader(\$classAliasLoader);
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -28,7 +28,7 @@ class Config
     const AUTOLOAD_MODE_FORCE_ALIAS_LOADING = 'force-alias-loading';
 
     /**
-     * Default values
+     * Default config values
      *
      * @var array
      */
@@ -37,6 +37,18 @@ class Config
         self::OPTION_ALWAYS_ADD_ALIAS_LOADER => false,
         self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE => true,
         self::OPTION_AUTOLOAD_MODE => self::AUTOLOAD_MODE_NORMAL,
+    );
+
+    /**
+     * Config cast types
+     *
+     * @var array
+     */
+    protected $configCastType = array(
+        self::OPTION_CLASS_ALIAS_MAPS => 'array',
+        self::OPTION_ALWAYS_ADD_ALIAS_LOADER => 'bool',
+        self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE => 'bool',
+        self::OPTION_AUTOLOAD_MODE => 'string',
     );
 
      /**
@@ -85,14 +97,28 @@ class Config
     protected function setAliasLoaderConfigFromPackage(PackageInterface $package)
     {
         $extraConfig = $this->handleDeprecatedConfigurationInPackage($package);
-        if (isset($extraConfig['typo3/class-alias-loader'][self::OPTION_CLASS_ALIAS_MAPS])) {
-            $this->config[self::OPTION_CLASS_ALIAS_MAPS] = (array)$extraConfig['typo3/class-alias-loader'][self::OPTION_CLASS_ALIAS_MAPS];
-        }
-        if (isset($extraConfig['typo3/class-alias-loader'][self::OPTION_ALWAYS_ADD_ALIAS_LOADER])) {
-            $this->config[self::OPTION_ALWAYS_ADD_ALIAS_LOADER] = (bool)$extraConfig['typo3/class-alias-loader'][self::OPTION_ALWAYS_ADD_ALIAS_LOADER];
-        }
-        if (isset($extraConfig['typo3/class-alias-loader'][self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE])) {
-            $this->config[self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE] = (bool)$extraConfig['typo3/class-alias-loader'][self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE];
+
+        foreach ($this->configCastType as $key => $type) {
+
+            if (isset($extraConfig['typo3/class-alias-loader'][$key])) {
+                $value = $extraConfig['typo3/class-alias-loader'][$key];
+
+                // Cast correct type
+                switch ($type) {
+                    case 'bool':
+                        $value = (bool) $value;
+                        break;
+                    case 'array':
+                        $value = (array) $value;
+                        break;
+                    case 'string':
+                        $value = (string) $value;
+                        break;
+                }
+
+                // Save value
+                $this->config[$key] = $value;
+            }
         }
     }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -19,15 +19,24 @@ use Composer\Package\PackageInterface;
  */
 class Config
 {
+    const OPTION_CLASS_ALIAS_MAPS = 'class-alias-maps';
+    const OPTION_ALWAYS_ADD_ALIAS_LOADER = 'always-add-alias-loader';
+    const OPTION_AUTOLOAD_IS_CASE_SENSITIVE = 'autoload-case-sensitivity';
+    const OPTION_AUTOLOAD_MODE = 'autoload-mode';
+
+    const AUTOLOAD_MODE_NORMAL = 'normal';
+    const AUTOLOAD_MODE_FORCE_ALIAS_LOADING = 'force-alias-loading';
+
     /**
      * Default values
      *
      * @var array
      */
     protected $config = array(
-        'class-alias-maps' => null,
-        'always-add-alias-loader' => false,
-        'autoload-case-sensitivity' => true
+        self::OPTION_CLASS_ALIAS_MAPS => null,
+        self::OPTION_ALWAYS_ADD_ALIAS_LOADER => false,
+        self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE => true,
+        self::OPTION_AUTOLOAD_MODE => self::AUTOLOAD_MODE_NORMAL,
     );
 
      /**
@@ -76,14 +85,14 @@ class Config
     protected function setAliasLoaderConfigFromPackage(PackageInterface $package)
     {
         $extraConfig = $this->handleDeprecatedConfigurationInPackage($package);
-        if (isset($extraConfig['typo3/class-alias-loader']['class-alias-maps'])) {
-            $this->config['class-alias-maps'] = (array)$extraConfig['typo3/class-alias-loader']['class-alias-maps'];
+        if (isset($extraConfig['typo3/class-alias-loader'][self::OPTION_CLASS_ALIAS_MAPS])) {
+            $this->config[self::OPTION_CLASS_ALIAS_MAPS] = (array)$extraConfig['typo3/class-alias-loader'][self::OPTION_CLASS_ALIAS_MAPS];
         }
-        if (isset($extraConfig['typo3/class-alias-loader']['always-add-alias-loader'])) {
-            $this->config['always-add-alias-loader'] = (bool)$extraConfig['typo3/class-alias-loader']['always-add-alias-loader'];
+        if (isset($extraConfig['typo3/class-alias-loader'][self::OPTION_ALWAYS_ADD_ALIAS_LOADER])) {
+            $this->config[self::OPTION_ALWAYS_ADD_ALIAS_LOADER] = (bool)$extraConfig['typo3/class-alias-loader'][self::OPTION_ALWAYS_ADD_ALIAS_LOADER];
         }
-        if (isset($extraConfig['typo3/class-alias-loader']['autoload-case-sensitivity'])) {
-            $this->config['autoload-case-sensitivity'] = (bool)$extraConfig['typo3/class-alias-loader']['autoload-case-sensitivity'];
+        if (isset($extraConfig['typo3/class-alias-loader'][self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE])) {
+            $this->config[self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE] = (bool)$extraConfig['typo3/class-alias-loader'][self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE];
         }
     }
 
@@ -106,15 +115,15 @@ class Config
                 );
             } else {
                 $extraConfig['typo3/class-alias-loader'] = array();
-                if (isset($extraConfig['class-alias-maps'])) {
-                    $extraConfig['typo3/class-alias-loader']['class-alias-maps'] = $extraConfig['class-alias-maps'];
+                if (isset($extraConfig[self::OPTION_CLASS_ALIAS_MAPS])) {
+                    $extraConfig['typo3/class-alias-loader'][self::OPTION_CLASS_ALIAS_MAPS] = $extraConfig[self::OPTION_CLASS_ALIAS_MAPS];
                     $messages[] = sprintf(
                         '<warning>The package "%s" uses "class-alias-maps" section on top level, which is deprecated. Please move this config below the top level key "typo3/class-alias-loader" instead!</warning>',
                         $package->getName()
                     );
                 }
-                if (isset($extraConfig['autoload-case-sensitivity'])) {
-                    $extraConfig['typo3/class-alias-loader']['autoload-case-sensitivity'] = $extraConfig['autoload-case-sensitivity'];
+                if (isset($extraConfig[self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE])) {
+                    $extraConfig['typo3/class-alias-loader'][self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE] = $extraConfig[self::OPTION_AUTOLOAD_IS_CASE_SENSITIVE];
                     $messages[] = sprintf(
                         '<warning>The package "%s" uses "autoload-case-sensitivity" section on top level, which is deprecated. Please move this config below the top level key "typo3/class-alias-loader" instead!</warning>',
                         $package->getName()

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -114,6 +114,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 'typo3/class-alias-loader' => array(
                     'always-add-alias-loader' => true,
                     'autoload-case-sensitivity' => false,
+                    'autoload-mode' => 'test',
                 )
             )
         );
@@ -122,6 +123,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($subject->get('always-add-alias-loader'));
         $this->assertFalse($subject->get('autoload-case-sensitivity'));
+        $this->assertEquals('test', $subject->get('autoload-mode'));
     }
 
     /**
@@ -134,6 +136,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 'helhum/class-alias-loader' => array(
                     'always-add-alias-loader' => true,
                     'autoload-case-sensitivity' => false,
+
                 )
             )
         );

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -60,6 +60,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->subject->get('always-add-alias-loader'));
         $this->assertTrue($this->subject->get('autoload-case-sensitivity'));
         $this->assertNull($this->subject->get('class-alias-maps'));
+        $this->assertEquals('normal', $this->subject->get('autoload-mode'));
     }
 
     /**


### PR DESCRIPTION
This PR adds the ability to configure Class Alias Loader so that all class_alias maps are loaded on boot, rather than as a pre-loader to the standard auto-loader.

This behaviour can be activated by specifying:
```
    "extra": {
        "typo3/class-alias-loader": {
            "autoloader-mode": "force-alias-loading"
        }
    },
```

It merely cycles all the known class aliases (specified via Composer) and executes the class_alias call for each, providing a class name is not already loaded.

## Risks

This autoloading method bypasses some of the safeties integrated in class-alias-loader:
 - All aliases are loaded at bootup. If you have a lot of aliases, this could badly affect startup performance.
 - Probably more likely that a bad alias, or dual-definition of a class will cause errors.
 - class-alias-loader doesn't run as an autoloader when this is enabled. Boo-hoo.

## But Why

We're using Symfony and want to relocate some classes from `A/B/C` to `D/E/F`.
This can be achieved simply enough using class_alias, but by using `class-alias-loader` this makes integration a hundred times cleaner, and in prototype and development this worked a charm.

Unfortunately in production we also use `ApcClassLoader`, which wraps the Composer autoloader and caches the locations of Files which represent class names to be loaded. 
This significantly speeds up production class autoloading when your project is as _enormo-huge_ as ours.

`ApcClassLoader` needs to be at the top of the autoloading stack in order to intercept most (if not all) autoloader calls and load them from memory, rather than Composer.
`ClassAliasLoader`, which is loaded immediately after Composer's AutoLoader, also wants to be at the top of the stack.

Once symfony has booted, we end up with a structure like this:
```
ApcClassLoader
   ClassLoader
ClassAliasLoader
   ClassLoader
```

For whatever reason (I've not fully debugged it) the `ApcClassLoader` ended up obtaining a reference for the `ClassAliasName => RealClassFileName`, meaning that when it saw a reference to an *Alias* class name, it loaded the file for the *REAL* class name.

This results in the *real* class file being loaded, but as `ClassAliasLoader` is never called the *alias* is never established.

## Other options

I tried putting the `ClassAliasLoader` in front of the `ApcClassLoader`, but the issue still occurred. It was also a performance problem to place that autoloader first when the `ApcClassLoader` should be prioritised in 99.999% of class loading cases.

I also tried letting the `ApcClassLoader` fail over to the `ClassAliasLoader` (as its next in the autoloader stack) but the ApcClassLoader was still ending up with the rogue class reference.

Besides this, we have some super bizzarro class referencing code that makes me wonder if it's even safe to lazy-load the class aliases on auto-load request. 

Rather than poke these bears, I've chosen to just make `class-alias-loader` force-load all class_alias mappings at boot, and avoid heavy modifications to our complex applications class autoloader.