### PR TITLE
before PHP 5.5 without '::class' constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ The '::class' constant is not available before PHP 5.5. Under a PHP before 5.5 t
 ```
 <?php
 return array(
-    'Tx_About_Controller_AboutController' => '\TYPO3\CMS\About\Controller\AboutController',
-    'Tx_About_Domain_Model_Extension' => '\TYPO3\CMS\About\Domain\Model\Extension',
-    'Tx_About_Domain_Repository_ExtensionRepository' => '\TYPO3\CMS\About\Domain\Repository\ExtensionRepository',
-    'Tx_Aboutmodules_Controller_ModulesController' => '\TYPO3\CMS\Aboutmodules\Controller\ModulesController',
+    'Tx_About_Controller_AboutController' => 'TYPO3\\CMS\\About\\Controller\\AboutController',
+    'Tx_About_Domain_Model_Extension' => 'TYPO3\\CMS\\About\\Domain\\Model\\Extension',
+    'Tx_About_Domain_Repository_ExtensionRepository' => 'TYPO3\\CMS\\About\\Domain\\Repository\\ExtensionRepository',
+    'Tx_Aboutmodules_Controller_ModulesController' => 'TYPO3\\CMS\\Aboutmodules\\Controller\\ModulesController',
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ return array(
 );
 ```
 
+The '::class' constant is not available before PHP 5.5. Under a PHP before 5.5 the mapping file can look like this:
+
+```
+<?php
+return array(
+    'Tx_About_Controller_AboutController' => '\TYPO3\CMS\About\Controller\AboutController',
+    'Tx_About_Domain_Model_Extension' => '\TYPO3\CMS\About\Domain\Model\Extension',
+    'Tx_About_Domain_Repository_ExtensionRepository' => '\TYPO3\CMS\About\Domain\Repository\ExtensionRepository',
+    'Tx_Aboutmodules_Controller_ModulesController' => '\TYPO3\CMS\Aboutmodules\Controller\ModulesController',
+);
+```
+
 In your *root* `composer.json` file, you can decide whether to allow classes to be found that are requested with wrong casing.
 Since PHP is case insensitive for class names, but PSR class loading standards bound file names to class names, class names de facto
 become case sensitive. For legacy packages it may be useful however to allow class names to be loaded even if wrong casing is provided.


### PR DESCRIPTION
see http://php.net/manual/en/language.oop5.constants.php