### PR TITLE
Remove extra space in console output

### DIFF
--- a/src/ClassAliasMapGenerator.php
+++ b/src/ClassAliasMapGenerator.php
@@ -117,7 +117,7 @@ class ClassAliasMapGenerator
         }
 
         $caseSensitiveClassLoadingString = $caseSensitiveClassLoading ? 'true' : 'false';
-        $this->IO->write('<info>Generating ' . ($classAliasMappingFound ? ' ' : 'empty ') . 'class alias map file</info>');
+        $this->IO->write('<info>Generating ' . ($classAliasMappingFound ? '' : 'empty ') . 'class alias map file</info>');
         $this->generateAliasMapFile($aliasToClassNameMapping, $classNameToAliasMapping, $targetDir);
 
         $suffix = null;


### PR DESCRIPTION
Don't add an additional single space if $classAliasMappingFound is true.