### PR TITLE
Keep same return for class names without alias

### DIFF
--- a/src/ClassAliasLoader.php
+++ b/src/ClassAliasLoader.php
@@ -149,6 +149,9 @@ class ClassAliasLoader
     {
         // Is an original class which has an alias
         if (array_key_exists($aliasOrClassName, $this->aliasMap['classNameToAliasMapping'])) {
+            if ($this->aliasMap['classNameToAliasMapping'][$aliasOrClassName] === null) {
+                return null;
+            }
             return $aliasOrClassName;
         }
 


### PR DESCRIPTION
Current intention of `ClassAliasLoader::getOriginalClassName` is `to return `NULL if no alias mapping is found or the original class name as string`

But the behaviour actually sets a NULL value in case a alias mapping is not found. This would lead on a second call to catch into the first condition which then returns the input parameter class name. This in case leads to the error that `ClassAliasLoader::loadClassWithAlias` will call `loadOriginalClassAndSetAliases` on a second try cause the return value is no more NULL but then the class name that was given as parameter. In some cases like for testing this results into PHP Warnings :)

The fix will now check if the value has already been set to NULL and returns the same result like in the first call.