### PR TITLE
[TASK] Have a phpunit.xml.dist that fails with E_ALL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 /.php_cs.dist export-ignore
 /.github export-ignore
 /tests
+/phpunit.xml.dist export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,4 +35,4 @@ jobs:
         run: composer update
 
       - name: Run test suite
-        run: vendor/bin/phpunit --colors tests/Unit/
+        run: vendor/bin/phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        cacheResult="false"
+        colors="true"
+        convertDeprecationsToExceptions="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        forceCoversAnnotation="false"
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        verbose="false"
+>
+    <testsuites>
+        <testsuite name="Unit tests">
+            <directory>tests/Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
+</phpunit>


### PR DESCRIPTION
Introduce phpunit.xml.dist and let tests fail
on E_ALL, not only E_ALL & ~E_DEPRECATED & ~E_STRICT.
This helps to introduce younger PHP versions
deprecation free.