### PR TITLE
Add support for PHP 8.4 (drop <7.1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v2
@@ -28,13 +28,7 @@ jobs:
           find src/ tests/ -name '*.php' -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
 
       - name: Install dependencies
-        if: ${{ matrix.php <= '8.1' }}
         run: composer update
-
-      - name: Install dependencies PHP 8.2
-        # @todo: Needed until prophecy (req by phpunit) allows PHP 8.2, https://github.com/phpspec/prophecy/issues/556
-        if: ${{ matrix.php > '8.1' }}
-        run: composer update --ignore-platform-req=php+
 
       - name: Run test suite
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "psr-4": { "TYPO3\\ClassAliasLoader\\Test\\": "tests/"}
     },
     "require": {
-        "php": ">=5.3.7",
+        "php": ">=7.1",
         "composer-plugin-api": "^1.0 || ^2.0"
     },
     "require-dev": {

--- a/src/ClassAliasMapGenerator.php
+++ b/src/ClassAliasMapGenerator.php
@@ -46,7 +46,7 @@ class ClassAliasMapGenerator
      * @param Composer $composer
      * @param IOInterface $io
      */
-    public function __construct(Composer $composer, IOInterface $io = null, $config = null)
+    public function __construct(Composer $composer, ?IOInterface $io = null, $config = null)
     {
         $this->composer = $composer;
         $this->io = $io ?: new NullIO();

--- a/src/Config.php
+++ b/src/Config.php
@@ -39,7 +39,7 @@ class Config
      * @param PackageInterface $package
      * @param IOInterface $io
      */
-    public function __construct(PackageInterface $package, IOInterface $io = null)
+    public function __construct(PackageInterface $package, ?IOInterface $io = null)
     {
         $this->io = $io ?: new NullIO();
         $this->setAliasLoaderConfigFromPackage($package);
@@ -55,7 +55,8 @@ class Config
             throw new \InvalidArgumentException('Configuration key must not be empty', 1444039407);
         }
         // Extract parts of the path
-        $configKey = str_getcsv($configKey, '.');
+        $configKey = str_getcsv($configKey, '.',  '"', '\\');
+
         // Loop through each part and extract its value
         $value = $this->config;
         foreach ($configKey as $segment) {

--- a/src/IncludeFile.php
+++ b/src/IncludeFile.php
@@ -48,7 +48,7 @@ class IncludeFile
      * @param TokenInterface[] $tokens
      * @param Filesystem $filesystem
      */
-    public function __construct(IOInterface $io, Composer $composer, array $tokens, Filesystem $filesystem = null)
+    public function __construct(IOInterface $io, Composer $composer, array $tokens, ?Filesystem $filesystem = null)
     {
         $this->io = $io;
         $this->composer = $composer;


### PR DESCRIPTION
This PR is an alternative to https://github.com/TYPO3/class-alias-loader/pull/32.
It drops support for PHP <7.1 in order to support PHP 8.4 deprecation free without requiring arguments to be removed or added.
(Changing arguments caused issues in previous changes, because old and new code is mixed during `composer update` withing one process)