### PR TITLE
[BUGFIX] Make InstalledVersions work again

### DIFF
--- a/src/ClassAliasLoader.php
+++ b/src/ClassAliasLoader.php
@@ -98,7 +98,7 @@ class ClassAliasLoader
      */
     public function register($prepend = false)
     {
-        $this->composerClassLoader->unregister();
+        spl_autoload_unregister(array($this->composerClassLoader, 'loadClass'));
         spl_autoload_register(array($this, 'loadClassWithAlias'), true, $prepend);
     }
 

--- a/tests/Unit/ClassAliasLoaderTest.php
+++ b/tests/Unit/ClassAliasLoaderTest.php
@@ -49,15 +49,6 @@ class ClassAliasLoaderTest extends BaseTestCase
     /**
      * @test
      */
-    public function registeringTheAliasLoaderUnregistersComposerClassLoader()
-    {
-        $this->composerClassLoaderMock->expects($this->once())->method('unregister');
-        $this->subject->register();
-    }
-
-    /**
-     * @test
-     */
     public function composerLoadClassIsCalledOnlyOnceWhenCaseSensitiveClassLoadingIsOn()
     {
         $this->composerClassLoaderMock->expects($this->once())->method('loadClass');


### PR DESCRIPTION
When including multiple autoload.php files during
the same runtime, Composer InstalledVersions relies
on the registered autoloaders to be able to resolve
all available packages. If class alias loader is now
calling ->unregister API, the static registry of available
classes is removed, which does not reflect the state
when class alias loader is registered.

Therefore, we now call spl_autoload_unregister ourselves
instead of using the API, because the classes will
be loadable, just not directly but proxied through
class alias loader